### PR TITLE
Feat: TabBarController 구현, 홈/검색/좋아요 화면 연결

### DIFF
--- a/PocketTheater.xcodeproj/project.pbxproj
+++ b/PocketTheater.xcodeproj/project.pbxproj
@@ -31,6 +31,12 @@
 		996BD15C2CB53808007F6C57 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996BD15B2CB53808007F6C57 /* UIViewController+Extension.swift */; };
 		996BD1602CB539EB007F6C57 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996BD15F2CB539EB007F6C57 /* BaseView.swift */; };
 		996BD1622CB53A96007F6C57 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996BD1612CB53A96007F6C57 /* Resource.swift */; };
+		C4DAFA5F2CB659BF0063B4B3 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA5E2CB659BF0063B4B3 /* HomeView.swift */; };
+		C4DAFA612CB659C60063B4B3 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA602CB659C60063B4B3 /* HomeViewController.swift */; };
+		C4DAFA632CB659E50063B4B3 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA622CB659E50063B4B3 /* SearchView.swift */; };
+		C4DAFA652CB659F40063B4B3 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA642CB659F40063B4B3 /* SearchViewController.swift */; };
+		C4DAFA672CB65A050063B4B3 /* LikeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA662CB65A050063B4B3 /* LikeView.swift */; };
+		C4DAFA692CB65A0F0063B4B3 /* LikeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DAFA682CB65A0F0063B4B3 /* LikeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -65,6 +71,12 @@
 		996BD15B2CB53808007F6C57 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		996BD15F2CB539EB007F6C57 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		996BD1612CB53A96007F6C57 /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
+		C4DAFA5E2CB659BF0063B4B3 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		C4DAFA602CB659C60063B4B3 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		C4DAFA622CB659E50063B4B3 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		C4DAFA642CB659F40063B4B3 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		C4DAFA662CB65A050063B4B3 /* LikeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeView.swift; sourceTree = "<group>"; };
+		C4DAFA682CB65A0F0063B4B3 /* LikeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				996BD13B2CB52E48007F6C57 /* TabBar */,
+				C4DAFA5C2CB659A80063B4B3 /* Home */,
 				996BD1342CB52DAF007F6C57 /* Trending */,
 				996BD1352CB52DB8007F6C57 /* Search */,
 				996BD1362CB52DBC007F6C57 /* Like */,
@@ -219,6 +232,8 @@
 		996BD1352CB52DB8007F6C57 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				C4DAFA622CB659E50063B4B3 /* SearchView.swift */,
+				C4DAFA642CB659F40063B4B3 /* SearchViewController.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -226,6 +241,8 @@
 		996BD1362CB52DBC007F6C57 /* Like */ = {
 			isa = PBXGroup;
 			children = (
+				C4DAFA662CB65A050063B4B3 /* LikeView.swift */,
+				C4DAFA682CB65A0F0063B4B3 /* LikeViewController.swift */,
 			);
 			path = Like;
 			sourceTree = "<group>";
@@ -251,6 +268,15 @@
 				996BD1552CB5322F007F6C57 /* ViewModelType.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		C4DAFA5C2CB659A80063B4B3 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				C4DAFA5E2CB659BF0063B4B3 /* HomeView.swift */,
+				C4DAFA602CB659C60063B4B3 /* HomeViewController.swift */,
+			);
+			path = Home;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -345,13 +371,19 @@
 			files = (
 				996BD1312CB52BB3007F6C57 /* UIColor+Extension.swift in Sources */,
 				996BD1622CB53A96007F6C57 /* Resource.swift in Sources */,
+				C4DAFA5F2CB659BF0063B4B3 /* HomeView.swift in Sources */,
 				996BD15C2CB53808007F6C57 /* UIViewController+Extension.swift in Sources */,
 				996BD1072CB52780007F6C57 /* AppDelegate.swift in Sources */,
+				C4DAFA612CB659C60063B4B3 /* HomeViewController.swift in Sources */,
 				996BD1212CB528D4007F6C57 /* APIKey.swift in Sources */,
 				996BD1582CB53260007F6C57 /* NSObjectProtocol+Extension.swift in Sources */,
 				996BD15A2CB53354007F6C57 /* BaseViewController.swift in Sources */,
 				996BD1092CB52780007F6C57 /* SceneDelegate.swift in Sources */,
+				C4DAFA652CB659F40063B4B3 /* SearchViewController.swift in Sources */,
+				C4DAFA692CB65A0F0063B4B3 /* LikeViewController.swift in Sources */,
+				C4DAFA632CB659E50063B4B3 /* SearchView.swift in Sources */,
 				996BD12B2CB52A9D007F6C57 /* Constant.swift in Sources */,
+				C4DAFA672CB65A050063B4B3 /* LikeView.swift in Sources */,
 				996BD1602CB539EB007F6C57 /* BaseView.swift in Sources */,
 				996BD1562CB5322F007F6C57 /* ViewModelType.swift in Sources */,
 				996BD13A2CB52E28007F6C57 /* HomeTabBarController.swift in Sources */,

--- a/PocketTheater/Application/SceneDelegate.swift
+++ b/PocketTheater/Application/SceneDelegate.swift
@@ -15,8 +15,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
         
-        let vc = HomeTabBarController()
-        window?.rootViewController = vc
+        let tabBar = HomeTabBarController()
+        tabBar.setDefaultTabBar()
+        window?.rootViewController = tabBar
         window?.makeKeyAndVisible()
     }
 

--- a/PocketTheater/Component/Base/BaseViewController.swift
+++ b/PocketTheater/Component/Base/BaseViewController.swift
@@ -11,7 +11,7 @@ class BaseViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = Resource.Color.white
+        view.backgroundColor = Resource.Color.black
         setViewController()
     }
     

--- a/PocketTheater/Presentation/Home/HomeView.swift
+++ b/PocketTheater/Presentation/Home/HomeView.swift
@@ -1,0 +1,31 @@
+//
+//  HomeView.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class HomeView: BaseView {
+    
+    /// `다음에 작업하는 사람이 지우고 작업해 주세요~!`
+    private let testLabel = UILabel().then {
+        $0.text = "홈 화면입니다."
+        $0.textColor = Resource.Color.white
+    }
+    
+    override func setHierarchy() {
+        self.addSubview(testLabel)
+    }
+    
+    override func setLayout() {
+        testLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.equalTo(100)
+        }
+    }
+    
+}

--- a/PocketTheater/Presentation/Home/HomeViewController.swift
+++ b/PocketTheater/Presentation/Home/HomeViewController.swift
@@ -1,0 +1,26 @@
+//
+//  HomeViewController.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import Foundation
+
+class HomeViewController: BaseViewController {
+    
+    private let homeView = HomeView()
+    
+    override func loadView() {
+        view = homeView
+    }
+    
+    override func viewDidLoad() {
+        print("Init HomeViewController")
+    }
+    
+    deinit {
+        print("Deinit HomeViewController")
+    }
+    
+}

--- a/PocketTheater/Presentation/Like/LikeView.swift
+++ b/PocketTheater/Presentation/Like/LikeView.swift
@@ -1,0 +1,29 @@
+//
+//  LikeView.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import UIKit
+
+class LikeView: BaseView {
+    
+    /// `다음에 작업하는 사람이 지우고 작업해 주세요~!`
+    private let testLabel = UILabel().then {
+        $0.text = "좋아요 화면입니다."
+        $0.textColor = Resource.Color.white
+    }
+    
+    override func setHierarchy() {
+        self.addSubview(testLabel)
+    }
+    
+    override func setLayout() {
+        testLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.equalTo(100)
+        }
+    }
+    
+}

--- a/PocketTheater/Presentation/Like/LikeViewController.swift
+++ b/PocketTheater/Presentation/Like/LikeViewController.swift
@@ -1,0 +1,26 @@
+//
+//  LikeViewController.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import Foundation
+
+class LikeViewController: BaseViewController {
+
+    private let likeView = LikeView()
+    
+    override func loadView() {
+        view = likeView
+    }
+    
+    override func viewDidLoad() {
+        print("Init LikeViewController")
+    }
+    
+    deinit {
+        print("Deinit LikeViewController")
+    }
+    
+}

--- a/PocketTheater/Presentation/Search/SearchView.swift
+++ b/PocketTheater/Presentation/Search/SearchView.swift
@@ -1,0 +1,29 @@
+//
+//  SearchView.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import UIKit
+
+class SearchView: BaseView {
+    
+    /// `다음에 작업하는 사람이 지우고 작업해 주세요~!`
+    private let testLabel = UILabel().then {
+        $0.text = "검색 화면입니다."
+        $0.textColor = Resource.Color.white
+    }
+    
+    override func setHierarchy() {
+        self.addSubview(testLabel)
+    }
+    
+    override func setLayout() {
+        testLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.equalTo(100)
+        }
+    }
+    
+}

--- a/PocketTheater/Presentation/Search/SearchViewController.swift
+++ b/PocketTheater/Presentation/Search/SearchViewController.swift
@@ -1,0 +1,26 @@
+//
+//  SearchViewController.swift
+//  PocketTheater
+//
+//  Created by junehee on 10/9/24.
+//
+
+import Foundation
+
+class SearchViewController: BaseViewController {
+    
+    private let searchView = SearchView()
+    
+    override func loadView() {
+        view = searchView
+    }
+    
+    override func viewDidLoad() {
+        print("Init SearchViewController")
+    }
+    
+    deinit {
+        print("Deinit SearchViewController")
+    }
+    
+}

--- a/PocketTheater/Presentation/TabBar/HomeTabBarController.swift
+++ b/PocketTheater/Presentation/TabBar/HomeTabBarController.swift
@@ -1,5 +1,5 @@
 //
-//  HomeTabBar.swift
+//  HomeTabBarController.swift
 //  PocketTheater
 //
 //  Created by 김윤우 on 10/8/24.
@@ -11,16 +11,15 @@ final class HomeTabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        setTabBarUI()
+        setTabBarUI()
     }
     
     func setDefaultTabBar() {
-//        let home = createTabBarItem(title: "홈", image: Resource.Image.home, viewController: HomeViewController())
-//        let search = createTabBarItem(title: "해시태그", image: Resource.Image.hashtag, viewController: HashTagViewController())
-//        let community = createTabBarItem(title: "커뮤니티", image: Resource.Image.board, viewController: CommunityViewController())
-//        let mypage = createTabBarItem(title: "마이페이지", image: Resource.Image.person, viewController: MyPageViewController())
-//        
-//        let viewControllers = [home, search, community, mypage]
+        let home = createTabBarItem(title: "Home", image: Resource.Image.house, viewController: HomeViewController())
+        let search = createTabBarItem(title: "Top Search", image: Resource.Image.search, viewController: SearchViewController())
+        let like = createTabBarItem(title: "Like", image: Resource.Image.smileFace, viewController: LikeViewController())
+        
+        let viewControllers = [home, search, like]
         self.setViewControllers(viewControllers, animated: true)
     }
     
@@ -36,11 +35,11 @@ final class HomeTabBarController: UITabBarController {
         return navigationController
     }
     
-//    private func setTabBarUI() {
-//        tabBar.backgroundColor = Resource.Color.paleGray
-//        tabBar.layer.borderWidth = 1
-//        tabBar.layer.borderColor = Resource.Color.lightGray.cgColor
-//        tabBar.tintColor = Resource.Color.purple
-//    }
-//    
+    private func setTabBarUI() {
+        tabBar.backgroundColor = Resource.Color.darkGray
+        // tabBar.layer.borderWidth = 1
+        // tabBar.layer.borderColor = Resource.Color.lightGray.cgColor
+        tabBar.barTintColor = .red
+        tabBar.tintColor = Resource.Color.white
+    }
 }

--- a/PocketTheater/Resource/Resource.swift
+++ b/PocketTheater/Resource/Resource.swift
@@ -35,20 +35,21 @@ enum Resource {
     }
 
     enum Image {
-        static let play = UIImage(systemName:  "play")
-        static let search = UIImage(systemName:  "magnifyingglass")
-        static let tv = UIImage(systemName:  "sparkles.tv")
-        static let house = UIImage(systemName:  "house")
-        static let playCircle = UIImage(systemName:  "play.circle")
-        static let download = UIImage(systemName:  "square.and.arrow.down")
-        static let smileFace = UIImage(systemName:  "face.smiling")
+        static let play = UIImage(systemName: "play")
+        static let search = UIImage(systemName: "magnifyingglass")
+        static let tv = UIImage(systemName: "sparkles.tv")
+        static let house = UIImage(systemName:  "house.fill")
+        static let playCircle = UIImage(systemName: "play.circle")
+        static let download = UIImage(systemName: "square.and.arrow.down")
+        static let smileFace = UIImage(systemName: "face.smiling.fill")
         static let plus = UIImage(systemName:  "plus")
     }
 
     enum Color {
         static let white = UIColor(hex: "FFFFFF") // 흰색
         static let black = UIColor(hex: "000000") // 검은색
-        static let darkGray = UIColor(hex: "1B1B1E") // 다크 그레이
+        static let eerieBlack = UIColor(hex: "1B1B1E") // 이리 블랙
+        static let darkGray = UIColor(hex: "373737") // 다크 그레이
         static let lightGray = UIColor(hex: "FC2125") // 레드
     }
 


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 작업
- [x] 디자인 작업
- [ ] 버그 수정
- [ ] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- 탭 바 컨트롤러 구현
- 각 탭에 홈/검색/좋아요 화면 연결

<br />

## 📱 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2024-10-09 at 16 05 47](https://github.com/user-attachments/assets/3a721d78-535c-48d7-86e9-49fdda3a89e3)


<br /><br />

## ⛓️ 관련 issue
closed #1 

<br />

## 📝 메모
- 화면 이동 확인을 위해 홈/검색/좋아요 화면에 간단한 레이블 추가해두었는데 추후 담당자가 삭제하고 진행해주시면 됩니다!
- Resource-Color 변동사항 : 탭 바 컨트롤러 색상이 없어서 darkGray 추가 후, 기존 darkGray를 eerieBlack으로 변경했습니당.
- Reosurce-Image 변동사항 : 홈 탭과 좋아요 탭에 사용되는 SF Symbols을 fill 스타일로 변경하였습니다.

| 기존 | 변경 |
|----|-----|
| <img width="350" alt="스크린샷 2024-10-09 오후 4 11 33" src="https://github.com/user-attachments/assets/ee9b9f1d-955a-4d51-8e3f-f9546e473deb"> | <img width="385" alt="스크린샷 2024-10-09 오후 4 10 44" src="https://github.com/user-attachments/assets/61bc7077-5adf-423f-9322-c890b630d0c5"> |

